### PR TITLE
add escape/unescape per http://nodejs.org/api/querystring.html

### DIFF
--- a/decode.js
+++ b/decode.js
@@ -64,8 +64,8 @@ module.exports = function(qs, sep, eq, options) {
       vstr = '';
     }
 
-    k = decodeURIComponent(kstr);
-    v = decodeURIComponent(vstr);
+    k = this.unescape(kstr);
+    v = this.unescape(vstr);
 
     if (!hasOwnProperty(obj, k)) {
       obj[k] = v;

--- a/escape.js
+++ b/escape.js
@@ -21,45 +21,4 @@
 
 'use strict';
 
-var stringifyPrimitive = function(v) {
-  switch (typeof v) {
-    case 'string':
-      return v;
-
-    case 'boolean':
-      return v ? 'true' : 'false';
-
-    case 'number':
-      return isFinite(v) ? v : '';
-
-    default:
-      return '';
-  }
-};
-
-module.exports = function(obj, sep, eq, name) {
-  var that = this;
-  sep = sep || '&';
-  eq = eq || '=';
-  if (obj === null) {
-    obj = undefined;
-  }
-
-  if (typeof obj === 'object') {
-    return Object.keys(obj).map(function(k) {
-      var ks = that.escape(stringifyPrimitive(k)) + eq;
-      if (Array.isArray(obj[k])) {
-        return obj[k].map(function(v) {
-          return ks + that.escape(stringifyPrimitive(v));
-        }).join(sep);
-      } else {
-        return ks + that.escape(stringifyPrimitive(obj[k]));
-      }
-    }).join(sep);
-
-  }
-
-  if (!name) return '';
-  return that.escape(stringifyPrimitive(name)) + eq +
-          that.escape(stringifyPrimitive(obj));
-};
+module.exports = encodeURIComponent;

--- a/index.js
+++ b/index.js
@@ -1,4 +1,13 @@
 'use strict';
 
-exports.decode = exports.parse = require('./decode');
-exports.encode = exports.stringify = require('./encode');
+module.exports = (function () {
+	var methods = {};
+
+	methods.decode = methods.parse = require('./decode');
+	methods.encode = methods.stringify = require('./encode');
+	methods.escape = require('./escape');
+	methods.unescape = require('./unescape');
+
+	return methods;
+}());
+

--- a/test/index.js
+++ b/test/index.js
@@ -208,3 +208,29 @@ exports['test nested in colon'] = function(assert) {
 
   assert.deepEqual({}, qs.parse(), 'parse undefined');
 };
+
+exports['test stringify() with escape() override'] = function(assert) {
+  var original = qs.escape;
+  qs.escape = function (value) { return value; };
+  var f = qs.stringify({a: 'a :'});
+  assert.equal(f, 'a=a :' , 'stringify with escape() override"');
+  qs.escape = original;
+};
+
+exports['test escape()'] = function(assert) {
+  var f = qs.escape('a :');
+  assert.equal(f, 'a%20%3A', 'escape "a :"');
+};
+
+exports['test parse() with unescape() override'] = function(assert) {
+  var original = qs.unescape;
+  qs.unescape = function (value) { return 'static'; };
+  var f = qs.parse('a=a :');
+  assert.deepEqual(f, {static: 'static'}, 'unescape "a :" with override"');
+  qs.unescape = original;
+};
+
+exports['test unescape()'] = function(assert) {
+  var f = qs.unescape('a%20%3A');
+  assert.equal(f, 'a :', 'unescape "a :"');
+};

--- a/unescape.js
+++ b/unescape.js
@@ -21,45 +21,4 @@
 
 'use strict';
 
-var stringifyPrimitive = function(v) {
-  switch (typeof v) {
-    case 'string':
-      return v;
-
-    case 'boolean':
-      return v ? 'true' : 'false';
-
-    case 'number':
-      return isFinite(v) ? v : '';
-
-    default:
-      return '';
-  }
-};
-
-module.exports = function(obj, sep, eq, name) {
-  var that = this;
-  sep = sep || '&';
-  eq = eq || '=';
-  if (obj === null) {
-    obj = undefined;
-  }
-
-  if (typeof obj === 'object') {
-    return Object.keys(obj).map(function(k) {
-      var ks = that.escape(stringifyPrimitive(k)) + eq;
-      if (Array.isArray(obj[k])) {
-        return obj[k].map(function(v) {
-          return ks + that.escape(stringifyPrimitive(v));
-        }).join(sep);
-      } else {
-        return ks + that.escape(stringifyPrimitive(obj[k]));
-      }
-    }).join(sep);
-
-  }
-
-  if (!name) return '';
-  return that.escape(stringifyPrimitive(name)) + eq +
-          that.escape(stringifyPrimitive(obj));
-};
+module.exports = decodeURIComponent;


### PR DESCRIPTION
add `escape()` and `unescape()` + minimal tests to show that they work as expected and (per the NodeJS documentation) can be overridden

This issue has been mentioned at:
https://github.com/Gozala/querystring/issues/6
https://github.com/mike-spainhower/querystring/issues/4
https://github.com/substack/node-browserify/issues/826
