### PR TITLE
Change multiple values to use array format

### DIFF
--- a/encode.js
+++ b/encode.js
@@ -37,9 +37,11 @@ var stringifyPrimitive = function(v) {
   }
 };
 
-module.exports = function(obj, sep, eq, name) {
+module.exports = function(obj, sep, eq, name, arrMode) {
   sep = sep || '&';
   eq = eq || '=';
+  arrMode = arrMode || false;
+  
   if (obj === null) {
     obj = undefined;
   }
@@ -48,7 +50,10 @@ module.exports = function(obj, sep, eq, name) {
     return Object.keys(obj).map(function(k) {
       var ks = encodeURIComponent(stringifyPrimitive(k)) + eq;
       if (Array.isArray(obj[k])) {
-        ks = encodeURIComponent(stringifyPrimitive(k)) + '[]' + eq;
+        if (arrMode) {
+          ks = encodeURIComponent(stringifyPrimitive(k)) + '[]' + eq;          
+        }
+
         return obj[k].map(function(v) {
           return ks + encodeURIComponent(stringifyPrimitive(v));
         }).join(sep);

--- a/encode.js
+++ b/encode.js
@@ -48,6 +48,7 @@ module.exports = function(obj, sep, eq, name) {
     return Object.keys(obj).map(function(k) {
       var ks = encodeURIComponent(stringifyPrimitive(k)) + eq;
       if (Array.isArray(obj[k])) {
+        ks = encodeURIComponent(stringifyPrimitive(k)) + '[]' + eq;
         return obj[k].map(function(v) {
           return ks + encodeURIComponent(stringifyPrimitive(v));
         }).join(sep);


### PR DESCRIPTION
When the object to be encoded contains an array, the resulting string simply repeats the key for each of the values. 

_Example:_

``` javascript
{foo: ['bar', 'baz', 'qux']}
```

Results in:

```
foo=bar&foo=baz&foo=qux
```

However, this only gives access to one of the values (typically the last one). I came across this issue when trying to use [oauth](https://www.npmjs.com/package/oauth) to generate a OAuth URL for the GitHub API.
The solution was to use the array convention to represent multiple values for the same key.

_Example:_

```
foo[]=bar&foo[]=baz&foo[]=qux
```

I don't know if you want to adopt this convention (as it can potentially break existing implementations), but in any case I've included the change in the PR.

**EDIT (25 July):** It doesn't make sense to just change the convention for everyone that's already using the package, so I've added an optional parameter to `encode()` that activates the array convention. It defaults to `false`, so everything should work exactly as is if the parameter isn't activated.

To activate it, `arrayMode` must be set to `true`. Because of the existing optional parameters in the function, it's necessary to actively set them to `undefined` in the function call — unfortunate, but in my opinion still better than not having this option at all.

_Example:_

``` javascript
querystring.encode({foo: ['bar', 'baz', 'qux']}, undefined, undefined, undefined, true);
```
