### PR TITLE
Specifing node module entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "bugs": {
     "url": "http://github.com/Gozala/querystring/issues/"
   },
+  "main": "index.js",
   "devDependencies": {
     "test": "~0.x.0",
     "phantomify": "~0.x.0",


### PR DESCRIPTION
Without it Systemjs Builder fail to load querystring.

Would be really nice if this could be pushed as minor release anytime soon.