### PR TITLE
Fix issue (#15) with empty arrays not stringify-ing consistently with node

### DIFF
--- a/encode.js
+++ b/encode.js
@@ -54,7 +54,7 @@ module.exports = function(obj, sep, eq, name) {
       } else {
         return ks + encodeURIComponent(stringifyPrimitive(obj[k]));
       }
-    }).join(sep);
+    }).filter(Boolean).join(sep);
 
   }
 

--- a/test/index.js
+++ b/test/index.js
@@ -100,6 +100,11 @@ var qsNoMungeTestCases = [
   ['trololol=yes&lololo=no', {'trololol': 'yes', 'lololo': 'no'}]
 ];
 
+var stringifyTestCases = [
+  ['', {'foo': []}],
+  ['bar=baz', {'foo': [], bar: 'baz'}],
+]
+
 exports['test basic'] = function(assert) {
   assert.strictEqual('918854443121279438895193',
                    qs.parse('id=918854443121279438895193').id,
@@ -153,6 +158,11 @@ exports['test stringifying'] = function(assert) {
   qsTestCases.forEach(function(testCase) {
     assert.equal(testCase[1], qs.stringify(testCase[2]),
                  'stringify ' + JSON.stringify(testCase[2]));
+  });
+
+  stringifyTestCases.forEach(function(testCase) {
+    assert.equal(testCase[0], qs.stringify(testCase[1]),
+                 'stringify ' + JSON.stringify(testCase[1]));
   });
 
   qsColonTestCases.forEach(function(testCase) {


### PR DESCRIPTION
Previously `stringify` was encoding empty arrays inconsistently with node's `querytring` module.

For example `stringify({ foo:'', bar:[], baz: '' }) => 'foo=&&baz='` - note the extra `&`.

By adding a `filter` call to the fragments of the querystring before `join`-ing then these empty strings are removed, and the query string is encoded correctly.

Fixes #15