### PR TITLE
fix the % decoding error

### DIFF
--- a/decode.js
+++ b/decode.js
@@ -38,6 +38,7 @@ module.exports = function(qs, sep, eq, options) {
   }
 
   var regexp = /\+/g;
+  qs = encodeURI(qs)
   qs = qs.split(sep);
 
   var maxKeys = 1000;

--- a/decode.js
+++ b/decode.js
@@ -28,6 +28,14 @@ function hasOwnProperty(obj, prop) {
   return Object.prototype.hasOwnProperty.call(obj, prop);
 }
 
+function safeDecodeURIComponent(value) {
+  try {
+    return decodeURIComponent(value)
+  } catch (e) {
+    return value
+  }
+}
+
 module.exports = function(qs, sep, eq, options) {
   sep = sep || '&';
   eq = eq || '=';
@@ -38,7 +46,6 @@ module.exports = function(qs, sep, eq, options) {
   }
 
   var regexp = /\+/g;
-  qs = encodeURI(qs)
   qs = qs.split(sep);
 
   var maxKeys = 1000;
@@ -65,8 +72,8 @@ module.exports = function(qs, sep, eq, options) {
       vstr = '';
     }
 
-    k = decodeURIComponent(kstr);
-    v = decodeURIComponent(vstr);
+    k = safeDecodeURIComponent(kstr);
+    v = safeDecodeURIComponent(vstr);
 
     if (!hasOwnProperty(obj, k)) {
       obj[k] = v;


### PR DESCRIPTION
## Description
<!--- Explain why this PR has to be merged, what originated this feature, ... -->

This PR fixes the #30 Issue.

**Before:**

* when parsing a query string containing a %, p.ex.: _'ka=va&kb=vb&kc&kd=%vd'_, the '%vd' decoding fails:

![image](https://user-images.githubusercontent.com/20399660/69439832-03284a80-0d48-11ea-8c90-087757f22857.png)

**After:**

* encoding the received data first, causes reserved chars to be valid for next decoding operation when the data is splitted and parsed separately:

![image](https://user-images.githubusercontent.com/20399660/69439954-39fe6080-0d48-11ea-8d2a-172169d4dead.png)

## Further considerations
<!--- If applies, add information of breaking changes, agreed deploy timings, ...  -->

* Current test system failed to me, so I've tested the solution with custom test code using mocha+chai for the test case. To reproduce it:

```
npm install mocha chai --save-dev
```

```
// ./test/indexTest.js

const expect = require('chai').expect

describe('querystring', () => {
  const qs = require('../index')
  describe('parse', () => {
    it('should parse query string key-value pairs', () => {
      const givenQS = 'ka=va&kb=vb'
      const expected = {
        ka: 'va',
        kb: 'vb'
      }
      const result = qs.parse(givenQS)
      expect(result).to.deep.equal(expected)
    })
    it('should parse query string key-only values', () => {
      const givenQS = 'ka=va&kb=vb&kc'
      const expected = {
        ka: 'va',
        kb: 'vb',
        kc: ''
      }
      const result = qs.parse(givenQS)
      expect(result).to.deep.equal(expected)
    })
    it('should parse query string with reserved chars', () => {
      const givenQS = 'ka=va&kb=vb&kc&kd=%vd'
      const expected = {
        ka: 'va',
        kb: 'vb',
        kc: '',
        kd: '%vd'
      }
      const result = qs.parse(givenQS)
      expect(result).to.deep.equal(expected)
    })
  })
})

```

