### PR TITLE
👷 Move to GitHub Actions

### DIFF
--- a/.github/workflows/ci-legacy.yml
+++ b/.github/workflows/ci-legacy.yml
@@ -1,0 +1,30 @@
+name: LEGACY
+
+on: push
+
+jobs:
+  test:
+    name: Test on Node ${{ matrix.node }} and ${{ matrix.os }}
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        node: ["0.8"]
+        os: [ubuntu-16.04]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup node ${{ matrix.node }}
+        uses: dcodeIO/setup-node-nvm@master
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Disabling Strict SSL
+        run: npm conf set strict-ssl false
+
+      - name: Installing Dependencies
+        run: npm install
+
+      - name: Running Tests
+        run: npm test

--- a/.github/workflows/ci-legacy.yml
+++ b/.github/workflows/ci-legacy.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node: ["0.8"]
+        node: ["0.8", "0.10", "0.12", "4", "6", "8"]
         os: [ubuntu-16.04]
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,3 @@ jobs:
 
       - name: Running Tests
         run: npm test
-
-      - name: Publish
-        if: startsWith(github.ref, 'refs/tags/') && matrix.os == 'ubuntu-latest' && matrix.node == '14.x'
-        run: echo "//registry.npmjs.org/:_authToken=$NPM_AUTH_TOKEN" > ~/.npmrc && npm publish --access public
-        env:
-          NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on: push
+
+jobs:
+  test:
+    name: Test on Node ${{ matrix.node }} and ${{ matrix.os }}
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        node: ["10.x", "12.x", "14.x"]
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Installing Dependencies
+        run: npm install
+
+      - name: Running Tests
+        run: npm test
+
+      - name: Publish
+        if: startsWith(github.ref, 'refs/tags/') && matrix.os == 'ubuntu-latest' && matrix.node == '14.x'
+        run: echo "//registry.npmjs.org/:_authToken=$NPM_AUTH_TOKEN" > ~/.npmrc && npm publish --access public
+        env:
+          NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,13 +7,8 @@ on:
 
 jobs:
   test:
-    name: Release ${{ matrix.node }} and ${{ matrix.os }}
-
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        node: ["14.x"]
-        os: [ubuntu-latest]
+    name: Release
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
@@ -21,7 +16,8 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node }}
+          node-version: 14.x
+          registry-url: https://registry.npmjs.org
 
       - name: Installing Dependencies
         run: npm install
@@ -29,7 +25,7 @@ jobs:
       - name: Running Tests
         run: npm test
 
-      - name: Publish
-        run: echo "//registry.npmjs.org/:_authToken=$NPM_AUTH_TOKEN" > ~/.npmrc && npm publish --access public
+      - name: Publishing to NPM
         env:
-          NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+        run: npm publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,8 @@ name: RELEASE
 
 on:
   push:
-    branches:
-      - master
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+
 
 jobs:
   test:
@@ -30,7 +30,6 @@ jobs:
         run: npm test
 
       - name: Publish
-        if: startsWith(github.ref, 'refs/tags/')
         run: echo "//registry.npmjs.org/:_authToken=$NPM_AUTH_TOKEN" > ~/.npmrc && npm publish --access public
         env:
           NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: RELEASE
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  test:
+    name: Release ${{ matrix.node }} and ${{ matrix.os }}
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        node: ["14.x"]
+        os: [ubuntu-latest]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Installing Dependencies
+        run: npm install
+
+      - name: Running Tests
+        run: npm test
+
+      - name: Publish
+        if: startsWith(github.ref, 'refs/tags/')
+        run: echo "//registry.npmjs.org/:_authToken=$NPM_AUTH_TOKEN" > ~/.npmrc && npm publish --access public
+        env:
+          NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,2 @@
 test
 .github
-CHANGELOG.md

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+test
+.github
+package-lock.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-language: node_js
-node_js:
-  - 0.6
-  - 0.8

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   },
   "devDependencies": {
     "test": "~0.x.0",
-    "phantomify": "~0.x.0",
     "retape": "~0.x.0",
     "tape": "~0.1.5"
   },
@@ -23,40 +22,9 @@
     "node": ">=0.4.x"
   },
   "scripts": {
-    "test": "npm run test-node && npm run test-browser && npm run test-tap",
-    "test-browser": "node ./node_modules/phantomify/bin/cmd.js ./test/common-index.js",
+    "test": "npm run test-node && npm run test-tap",
     "test-node": "node ./test/common-index.js",
     "test-tap": "node ./test/tap-index.js"
-  },
-  "testling": {
-    "files": "test/tap-index.js",
-    "browsers": {
-      "iexplore": [
-        9,
-        10
-      ],
-      "chrome": [
-        16,
-        20,
-        25,
-        "canary"
-      ],
-      "firefox": [
-        10,
-        15,
-        16,
-        17,
-        18,
-        "nightly"
-      ],
-      "safari": [
-        5,
-        6
-      ],
-      "opera": [
-        12
-      ]
-    }
   },
   "license": "MIT"
 }


### PR DESCRIPTION
Split from #46 

This PR is to move CI from Travis to GitHub Actions

 I'm not adding node 0.6 in legacy matrix since it's [not able to do setup and same fails on travis and GH actions both](https://github.com/Gozala/querystring/issues/48#issue-779222693) and even if setup succeds it keeps on throwing segment fault