### PR TITLE
Fix decodeFuncType to return Record<string, string|string[]>

### DIFF
--- a/decode.d.ts
+++ b/decode.d.ts
@@ -15,6 +15,6 @@ export type decodeFuncType = (
     decodeURIComponent?: Function;
     maxKeys?: number;
   }
-) => Record<any, unknown>;
+) => Record<string, string|string[]>;
 
 export default decodeFuncType;


### PR DESCRIPTION
This is reverse-engineered from the implementation.